### PR TITLE
Issue 152

### DIFF
--- a/graphs/templates/about.html
+++ b/graphs/templates/about.html
@@ -7,10 +7,9 @@
   <!-- SUB NAV Tab Content -->
   <div class="nav-content">
     <ul class="tabs tabs-transparent">
-      <li class="tab"><a href="#built-with">Built With</a></li>
       <li class="tab"><a href="#built-by">Built By</a></li>
+      <li class="tab"><a href="#built-with">Built With</a></li>
       <li class="tab"><a href="#acknowledgements">Acknowledgements</a></li>
-      <li class="tab"><a href="#related-tools">Related Tools</a></li>
     </ul>
   </div>
 
@@ -25,30 +24,8 @@
   <div class="section about">
 
     <!-- Tab 1 -->
-    <div id="built-with" >
-      <h3 class="center">Built With</h3>
-
-      <h6 class="white-text center tagline">Tools & Frameworks Used</h6>
-      <br>
-
-      <a href="https://www.python.org/">Python</a><br>
-      <a href="http://sigmajs.org/">Sigma.js</a><br>
-      <a href="https://www.djangoproject.com/">Django</a><br>
-      <a href="http://materializecss.com/">Materialize CSS</a><br>
-      <a href="https://vincentgarreau.com/particles.js/">Particles.js</a><br>
-      <a href="https://jquery.com/">jQuery</a><br>
-      <a href="https://www.heroku.com/">Heroku</a><br>
-    </div>
-
-    <!-- Tab 2 -->
     <div id="built-by">
       <h3 class="center">Built By</h3>
-      <section class="about-intro center">
-        <h6 class="white-text center tagline">The Codokans</h6>
-        <br>
-        <p>Originally developed by Mathieu Jacomy at the <a href="http://medialab.sciences-po.fr/">Sciences-Po Medialab</a>.</p>
-        <p>Refreshed, refactored and tuned up by <a href="#">The Codokans</a> in March 2018, a second year undergraduate computer science team from <a href="https://www.kcl.ac.uk/">King's College London</a>.</p>
-      </section>
 
       <!-- TODO Add modal with more info about The Codokans and links to our respective sites -->
 
@@ -240,6 +217,26 @@
           </div>
         </li>
       </ul>
+      <section class="about-intro center">
+        <p>Originally developed by Mathieu Jacomy at the <a href="http://medialab.sciences-po.fr/">Sciences-Po Medialab</a>.</p>
+        <p>Refreshed, refactored and tuned up by <a href="#">The Codokans</a> in March 2018, a second year undergraduate computer science team from <a href="https://www.kcl.ac.uk/">King's College London</a>.</p>
+      </section>
+    </div>
+
+    <!-- Tab 2 -->
+    <div id="built-with" >
+      <h3 class="center">Built With</h3>
+
+      <h6 class="white-text center tagline">Tools & Frameworks Used</h6>
+      <br>
+
+      <a href="https://www.python.org/">Python</a><br>
+      <a href="http://sigmajs.org/">Sigma.js</a><br>
+      <a href="https://www.djangoproject.com/">Django</a><br>
+      <a href="http://materializecss.com/">Materialize CSS</a><br>
+      <a href="https://vincentgarreau.com/particles.js/">Particles.js</a><br>
+      <a href="https://jquery.com/">jQuery</a><br>
+      <a href="https://www.heroku.com/">Heroku</a><br>
     </div>
 
     <!-- Tab 3 -->
@@ -251,20 +248,6 @@
         <li><b>Dr. Jeroen Keppens</b> and <b>Dr. Solon Pissis</b> of King's College London, for supervising the project and providing administrative support.</li>
         <li><b>Sebastian Grauwin</b>, for developing Bibliotools3.0, the back-end data processing prototype upon which ScienceScape<sup>S</sup> is based.</li>
       </ul>
-    </div>
-
-    <!-- Tab 4 -->
-    <div id="related-tools">
-      <h3 class="center">Related Tools</h3>
-
-      <h6 class="white-text center tagline">Some Tagline</h6>
-      <br>
-      <a href="https://tools.medialab.sciences-po.fr/table2net/">Table2Net</a><br>
-      <p>If you want to get the citation network from the table with the DOI, you can use Table2Net in "citation" mode.</p>
-      <a href="http://www.sebastian-grauwin.com/?page_id=492">BiblioTools</a><br>
-      <p>BiblioTools was developed by Sebastian Grauwin for a similar purpose. It is dedicated to getting networks from Web of Science, and can deal a large mass of data.</p>
-      <a href="http://gephi.org/">Gephi</a><br>
-      <p>We recommand to use Gephi for spatializing networks. It is more efficient than this website. Check its <a href="http://gephi.org/users/">tutorials</a></p>
     </div>
 
   </div> <!-- /section -->

--- a/static/css/extra.css
+++ b/static/css/extra.css
@@ -245,6 +245,7 @@ footer a {
      -webkit-flex-grow: 1 !important;
      -ms-flex-positive: 1 !important;
      flex-grow: 1 !important;
+     width: 33%;
  }
 
  .tabs .tab a {


### PR DESCRIPTION
Change contents of 'About' page including removal of unneeded 'Related Tools' section.

Note that materialize tabs (for About) have been forced to 33% width in CSS as, otherwise, 'Acknowledgements' is too long and forces the middle tab to not be centred with the menu bar logo.

Possible separate issue to find a better workaround?